### PR TITLE
Bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN eval `ssh-agent -s` && ssh-add ${SSHDIR}/id_rsa
 
 #################################################
 ## EFA and MPI SETUP
-RUN curl -O https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.5.0.tar.gz \
-    && tar -xf aws-efa-installer-1.5.0.tar.gz \
+RUN curl -O https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz \
+    && tar -xf aws-efa-installer-latest.tar.gz \
     && cd aws-efa-installer \
     && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ AWS_REGION=?
 ACCOUNT_ID=?
 
 all:
-  docker build . -t npb
+	docker build . -t npb
 
 login:
 	`aws ecr get-login --no-include-email --region ${AWS_REGION}`

--- a/conf/supervisord/supervisord.conf
+++ b/conf/supervisord/supervisord.conf
@@ -27,7 +27,7 @@ startretries=10
 
 [program:synchronize]
 user=efauser
-command=/supervised-scripts/mpi-run.sh
+command=bash /supervised-scripts/mpi-run.sh
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
   - Replace the spaces with tab in Makefile `all` section to avoid `make missing separator error`.
   - Execute mpi-run.sh explicitly with bash to avoid the ENOEXEC error
   - Replace the efa installer to be the latest one

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
